### PR TITLE
InjectForm#prefix()がデフォルト値の場合にエラープロパティ名の先頭に'.'がつかないように修正

### DIFF
--- a/src/main/java/nablarch/core/validation/ee/ConstraintViolationConverter.java
+++ b/src/main/java/nablarch/core/validation/ee/ConstraintViolationConverter.java
@@ -2,6 +2,7 @@ package nablarch.core.validation.ee;
 
 import nablarch.core.message.Message;
 import nablarch.core.message.StringResource;
+import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;
 import nablarch.core.validation.ValidationResultMessage;
 
@@ -34,7 +35,9 @@ public class ConstraintViolationConverter {
      * @param prefix バリデーション対象オブジェクトのプロパティ名に付与するプレフィクス
      */
     public ConstraintViolationConverter(String prefix) {
-        this.prefix = prefix + ".";
+        if (StringUtil.hasValue(prefix)) {
+            this.prefix = prefix + ".";
+        }
     }
 
     /**

--- a/src/test/java/nablarch/core/validation/ee/ConstraintViolationConverterTest.java
+++ b/src/test/java/nablarch/core/validation/ee/ConstraintViolationConverterTest.java
@@ -43,6 +43,25 @@ public class ConstraintViolationConverterTest {
         assertThat(vrm.formatMessage(), is("may not be null"));
     }
 
+    /**
+     * コンストラクタにprefixとして空文字を設定すると、エラーメッセージの
+     * プロパティ名にprefixが付加されないことを確認する.
+     */
+    @Test
+    public void testNotAddEmptyPrefixToPropertyName() {
+        ConstraintViolationConverter sut = new ConstraintViolationConverter("");
+        TestBean bean = new TestBean();
+        Set<ConstraintViolation<TestBean>> violations = validator.validate(bean);
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getPropertyPath().toString(), is("name"));
+
+        List<Message> convert = sut.convert(violations);
+        ValidationResultMessage vrm = (ValidationResultMessage) convert.get(0);
+        assertThat(vrm.getPropertyName(), is("name"));
+        assertThat(vrm.getMessageId(), is("javax.validation.constraints.NotNull"));
+        assertThat(vrm.formatMessage(), is("may not be null"));
+    }
+
     static class TestBean {
 
         private String name = null;


### PR DESCRIPTION
## Description

`InjectForm#prefix()`が指定されていない場合にも、`BeanValidationStrategy`が生成する`ValidationResultMessage`が正しいプロパティ名を持つように修正しました。

修正前は、`InjectForm#prefix()`が指定されていないときには、プロパティ名の先頭に`.`が付与されていました。
`InjectForm#prefix()`が指定されていない場合、プロパティ名をそのままにするように修正しています。(`NablarchValidationStrategy`と同じ振る舞いだと思います。)

before: `".name"`
after: `"name"`