### PR TITLE
JUnit4を現行バージョンにアップ

### DIFF
--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.nablarch.example</groupId>
   <artifactId>jaxrs-beanvalidation</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>5-NEXT-SNAPSHOT</version>
   <name>jaxrs-beanvalidation</name>
 
   <dependencyManagement>
@@ -73,18 +73,18 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-core-repository</artifactId>
-      <version>1.0.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-core-applog</artifactId>
-      <version>1.0.0</version>
+      <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.nablarch.configuration</groupId>
       <artifactId>nablarch-main-default-configuration</artifactId>
-      <version>1.0.0</version>
+      <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/acceptance-test/src/main/resources/ValidationMessages.properties
+++ b/acceptance-test/src/main/resources/ValidationMessages.properties
@@ -1,7 +1,0 @@
-nablarch.core.validation.ee.SystemChar.message={charsetDef}\u3067\u306a\u3044\u3067\u3059\u3088\u3002
-nablarch.core.validation.ee.Length.message=${min==0 ? max+="\u6587\u5b57\u4ee5\u5185" : max==2147483647 ? min+="\u6587\u5b57\u4ee5\u4e0a" : min+="\u6587\u5b57\u4ee5\u4e0a"+=max+="\u6587\u5b57\u4ee5\u5185"}\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-nablarch.core.validation.ee.Required.message=\u5fc5\u9808\u9805\u76ee\u3067\u3059\u3002
-nablarch.core.validation.ee.NumberRange.message=${min==(-1.0 / 0.0) ? max+="\u4ee5\u5185" : max==(1.0 / 0.0) ? min+="\u4ee5\u4e0a" : min+="\u4ee5\u4e0a"+=max+="\u4ee5\u5185"}\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-nablarch.core.validation.ee.Size.message=${min==0 ? max+="\u4ee5\u5185" : max==2147483647 ? min+="\u4ee5\u4e0a" : min+="\u4ee5\u4e0a"+=max+="\u4ee5\u5185"}\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-nablarch.core.validation.ee.Digits.message=\u6574\u6570\u90e8\u306f{integer}\u6841\u4ee5\u5185\u3001\u5c0f\u6570\u90e8\u306f{fraction}\u6841\u4ee5\u5185\u3067\u5165\u529b\u3057\u3066\u304f\u3060\u3055\u3044\u3002
-

--- a/acceptance-test/src/main/resources/messages.properties
+++ b/acceptance-test/src/main/resources/messages.properties
@@ -1,0 +1,7 @@
+nablarch.core.validation.ee.SystemChar.message={charsetDef}\u3067\u306A\u3044\u3067\u3059\u3088\u3002
+nablarch.core.validation.ee.Length.message=${min==0 ? max+="\u6587\u5B57\u4EE5\u5185" : max==2147483647 ? min+="\u6587\u5B57\u4EE5\u4E0A" : min+="\u6587\u5B57\u4EE5\u4E0A"+=max+="\u6587\u5B57\u4EE5\u5185"}\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002
+nablarch.core.validation.ee.Required.message=\u5FC5\u9808\u9805\u76EE\u3067\u3059\u3002
+nablarch.core.validation.ee.NumberRange.message=${min==(-1.0 / 0.0) ? max+="\u4EE5\u5185" : max==(1.0 / 0.0) ? min+="\u4EE5\u4E0A" : min+="\u4EE5\u4E0A"+=max+="\u4EE5\u5185"}\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002
+nablarch.core.validation.ee.Size.message=${min==0 ? max+="\u4EE5\u5185" : max==2147483647 ? min+="\u4EE5\u4E0A" : min+="\u4EE5\u4E0A"+=max+="\u4EE5\u5185"}\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002
+nablarch.core.validation.ee.Digits.message=\u6574\u6570\u90E8\u306F{integer}\u6841\u4EE5\u5185\u3001\u5C0F\u6570\u90E8\u306F{fraction}\u6841\u4EE5\u5185\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002
+nablarch.core.validation.ee.Length.max.message=\u6587\u5B57\u6570\u30AA\u30FC\u30D0\u30FC\u3067\u3059\u3002


### PR DESCRIPTION
# 概要

* 以下の修正を適用したいため、JUnit4のバージョンを上げました。
  https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md#security-fix-temporaryfolder-now-limits-access-to-temporary-folders-on-java-17-or-later
* 合わせてメンテされていなかったテストを動作するように修正しました。
* 本PRもリリース **不要** です。テストのみの修正のため。
