### PR TITLE
Jakarta EE 対応

### DIFF
--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.nablarch.example</groupId>
   <artifactId>jaxrs-beanvalidation</artifactId>
   <packaging>jar</packaging>
-  <version>5-NEXT-SNAPSHOT</version>
+  <version>6-NEXT-SNAPSHOT</version>
   <name>jaxrs-beanvalidation</name>
 
   <dependencyManagement>
@@ -26,6 +26,10 @@
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-grizzly2-http</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+    </dependency>
     <!-- uncomment this to get JSON support:
      <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
@@ -37,27 +41,23 @@
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-core-validation-ee</artifactId>
       <version>${project.version}</version>
+
+      <exclusions>
+        <exclusion>
+          <groupId>javax.validation</groupId>
+          <artifactId>validation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>
       <artifactId>jersey-bean-validation</artifactId>
-      <version>2.17</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.web</groupId>
-          <artifactId>javax.el</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.el</groupId>
-          <artifactId>javax.el-api</artifactId>
-        </exclusion>
-      </exclusions>
-
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>3.0.0</version>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -66,9 +66,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
@@ -120,7 +120,7 @@
   </build>
 
   <properties>
-    <jersey.version>2.17</jersey.version>
+    <jersey.version>3.0.2</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/acceptance-test/src/main/java/com/example/MyResource.java
+++ b/acceptance-test/src/main/java/com/example/MyResource.java
@@ -1,11 +1,11 @@
 package com.example;
 
-import javax.validation.Valid;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Root resource (exposed at "myresource" path)

--- a/acceptance-test/src/main/java/com/example/SampleBean.java
+++ b/acceptance-test/src/main/java/com/example/SampleBean.java
@@ -1,7 +1,7 @@
 package com.example;
 
 import java.util.List;
-import javax.ws.rs.QueryParam;
+import jakarta.ws.rs.QueryParam;
 
 import nablarch.core.validation.ee.Domain;
 import nablarch.core.validation.ee.Required;

--- a/acceptance-test/src/main/java/com/example/SampleDomain.java
+++ b/acceptance-test/src/main/java/com/example/SampleDomain.java
@@ -1,7 +1,7 @@
 package com.example;
 
 import java.util.List;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import nablarch.core.validation.ee.Length;
 import nablarch.core.validation.ee.NumberRange;

--- a/acceptance-test/src/test/java/com/example/MyResourceTest.java
+++ b/acceptance-test/src/test/java/com/example/MyResourceTest.java
@@ -1,10 +1,10 @@
 package com.example;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.junit.After;

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>7.0.0.Final</version>
+      <version>8.0.0.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>jakarta.el</artifactId>
-      <version>4.0.0</version>
+      <groupId>org.glassfish.expressly</groupId>
+      <artifactId>expressly</artifactId>
+      <version>5.0.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,20 +29,17 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>8.0.0.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.expressly</groupId>
       <artifactId>expressly</artifactId>
-      <version>5.0.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -67,7 +64,6 @@
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,24 +19,6 @@
     <artifactId>nablarch-parent</artifactId>
     <version>6-NEXT-SNAPSHOT</version>
   </parent>
-  
-  <profiles>
-    <profile>
-      <id>java11</id>
-      <dependencies>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <dependencies>
     <dependency>
@@ -45,22 +27,22 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>5.3.6.Final</version>
+      <version>7.0.0.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>3.0.0</version>
+      <artifactId>jakarta.el</artifactId>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -79,6 +61,13 @@
     <dependency>
       <groupId>com.nablarch.dev</groupId>
       <artifactId>nablarch-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/nablarch/core/validation/ee/ConstraintViolationConverter.java
+++ b/src/main/java/nablarch/core/validation/ee/ConstraintViolationConverter.java
@@ -6,7 +6,7 @@ import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;
 import nablarch.core.validation.ValidationResultMessage;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;

--- a/src/main/java/nablarch/core/validation/ee/DecimalRange.java
+++ b/src/main/java/nablarch/core/validation/ee/DecimalRange.java
@@ -12,9 +12,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;

--- a/src/main/java/nablarch/core/validation/ee/Digits.java
+++ b/src/main/java/nablarch/core/validation/ee/Digits.java
@@ -15,10 +15,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.math.BigDecimal;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 /**
  * 数値の整数部、小数部が指定された桁数以内であることを表すアノテーション。

--- a/src/main/java/nablarch/core/validation/ee/Domain.java
+++ b/src/main/java/nablarch/core/validation/ee/Domain.java
@@ -6,8 +6,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;

--- a/src/main/java/nablarch/core/validation/ee/DomainValidator.java
+++ b/src/main/java/nablarch/core/validation/ee/DomainValidator.java
@@ -1,10 +1,10 @@
 package nablarch.core.validation.ee;
 
 import java.util.Set;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 
 import nablarch.core.repository.SystemRepository;
 

--- a/src/main/java/nablarch/core/validation/ee/GroupSequenceManager.java
+++ b/src/main/java/nablarch/core/validation/ee/GroupSequenceManager.java
@@ -14,7 +14,7 @@ import nablarch.core.util.annotation.Published;
 public interface GroupSequenceManager {
 
     /**
-     * {@link javax.validation.GroupSequence}を定義したインタフェースの{@link Class}を取得する。
+     * {@link jakarta.validation.GroupSequence}を定義したインタフェースの{@link Class}を取得する。
      * 
      * @return グループシーケンスを既定したインタフェース
      */

--- a/src/main/java/nablarch/core/validation/ee/ItemNamedConstraintViolationConverterFactory.java
+++ b/src/main/java/nablarch/core/validation/ee/ItemNamedConstraintViolationConverterFactory.java
@@ -2,8 +2,8 @@ package nablarch.core.validation.ee;
 
 import java.util.Locale;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Path;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
 
 import nablarch.core.log.Logger;
 import nablarch.core.log.LoggerManager;

--- a/src/main/java/nablarch/core/validation/ee/Length.java
+++ b/src/main/java/nablarch/core/validation/ee/Length.java
@@ -7,10 +7,10 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 import static java.lang.annotation.ElementType.*;
 

--- a/src/main/java/nablarch/core/validation/ee/MultiLanguageMessageInterpolator.java
+++ b/src/main/java/nablarch/core/validation/ee/MultiLanguageMessageInterpolator.java
@@ -2,7 +2,7 @@ package nablarch.core.validation.ee;
 
 import java.util.Locale;
 
-import javax.validation.MessageInterpolator;
+import jakarta.validation.MessageInterpolator;
 
 import nablarch.core.ThreadContext;
 import nablarch.core.repository.SystemRepository;
@@ -34,8 +34,8 @@ public class MultiLanguageMessageInterpolator implements MessageInterpolator {
      * 使用する{@link Locale}は、{@link ThreadContext}に設定されている場合はその値を使用し、
      * そうでない場合は{@link Locale#getDefault()}の値を使用する。
      *
-     * @see javax.validation.MessageInterpolator#interpolate(java.lang.String,
-     * javax.validation.MessageInterpolator.Context)
+     * @see jakarta.validation.MessageInterpolator#interpolate(java.lang.String,
+     * jakarta.validation.MessageInterpolator.Context)
      */
     @Override
     public String interpolate(String messageKey, Context context) {
@@ -44,7 +44,7 @@ public class MultiLanguageMessageInterpolator implements MessageInterpolator {
 
     /**
      * {@link Context}に基づいてメッセージテンプレートからメッセージを生成する。<br/>
-     * @see javax.validation.MessageInterpolator#interpolate(java.lang.String, javax.validation.MessageInterpolator.Context, java.util.Locale)
+     * @see jakarta.validation.MessageInterpolator#interpolate(java.lang.String, jakarta.validation.MessageInterpolator.Context, java.util.Locale)
      */
     @Override
     public String interpolate(String messageKey, Context context, Locale locale) {

--- a/src/main/java/nablarch/core/validation/ee/NablarchMessageInterpolator.java
+++ b/src/main/java/nablarch/core/validation/ee/NablarchMessageInterpolator.java
@@ -4,8 +4,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import javax.validation.MessageInterpolator;
-import javax.validation.Validation;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.Validation;
 
 import nablarch.core.message.Message;
 import nablarch.core.message.MessageLevel;

--- a/src/main/java/nablarch/core/validation/ee/NumberRange.java
+++ b/src/main/java/nablarch/core/validation/ee/NumberRange.java
@@ -13,9 +13,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.math.BigDecimal;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;

--- a/src/main/java/nablarch/core/validation/ee/NumberValidatorSupport.java
+++ b/src/main/java/nablarch/core/validation/ee/NumberValidatorSupport.java
@@ -1,7 +1,7 @@
 package nablarch.core.validation.ee;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
 import java.util.regex.Pattern;

--- a/src/main/java/nablarch/core/validation/ee/Required.java
+++ b/src/main/java/nablarch/core/validation/ee/Required.java
@@ -6,10 +6,10 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;

--- a/src/main/java/nablarch/core/validation/ee/Size.java
+++ b/src/main/java/nablarch/core/validation/ee/Size.java
@@ -15,10 +15,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Collection;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 /**
  * 要素数が指定した値の範囲内であるかチェックするアノテーション。

--- a/src/main/java/nablarch/core/validation/ee/SystemChar.java
+++ b/src/main/java/nablarch/core/validation/ee/SystemChar.java
@@ -4,10 +4,10 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
 
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.annotation.Published;

--- a/src/main/java/nablarch/core/validation/ee/ValidatorFactoryBuilder.java
+++ b/src/main/java/nablarch/core/validation/ee/ValidatorFactoryBuilder.java
@@ -2,7 +2,7 @@ package nablarch.core.validation.ee;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ValidatorFactory;
 
 /**
  * {@link ValidatorFactory}を生成するクラス。

--- a/src/main/java/nablarch/core/validation/ee/ValidatorUtil.java
+++ b/src/main/java/nablarch/core/validation/ee/ValidatorUtil.java
@@ -6,10 +6,10 @@ import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.StringUtil;
 import nablarch.core.util.annotation.Published;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/src/test/java/nablarch/core/validation/ee/BeanValidationTestCase.java
+++ b/src/test/java/nablarch/core/validation/ee/BeanValidationTestCase.java
@@ -6,8 +6,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.repository.di.DiContainer;

--- a/src/test/java/nablarch/core/validation/ee/ConstraintViolationConverterTest.java
+++ b/src/test/java/nablarch/core/validation/ee/ConstraintViolationConverterTest.java
@@ -1,14 +1,17 @@
 package nablarch.core.validation.ee;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.NotNull;
 import nablarch.core.message.Message;
 import nablarch.core.validation.ValidationResultMessage;
+import org.junit.Before;
 import org.junit.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -21,8 +24,28 @@ import static org.junit.Assert.assertThat;
  */
 public class ConstraintViolationConverterTest {
 
-    Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    Validator validator;
 
+    @Before
+    public void setUp() throws Exception {
+        validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new MessageInterpolator() {
+                    private final MessageInterpolator delegate = Validation.buildDefaultValidatorFactory().getMessageInterpolator();
+
+                    @Override
+                    public String interpolate(String messageTemplate, Context context) {
+                        return interpolate(messageTemplate, context, Locale.ENGLISH);
+                    }
+
+                    @Override
+                    public String interpolate(String messageTemplate, Context context, Locale locale) {
+                        return delegate.interpolate(messageTemplate, context, locale);
+                    }
+                })
+                .buildValidatorFactory()
+                .getValidator();
+    }
 
     /**
      * コンストラクタにprefix設定すると、エラーメッセージの
@@ -39,8 +62,8 @@ public class ConstraintViolationConverterTest {
         List<Message> convert = sut.convert(violations);
         ValidationResultMessage vrm = (ValidationResultMessage) convert.get(0);
         assertThat(vrm.getPropertyName(), is("form.name"));
-        assertThat(vrm.getMessageId(), is("javax.validation.constraints.NotNull"));
-        assertThat(vrm.formatMessage(), is("may not be null"));
+        assertThat(vrm.getMessageId(), is("jakarta.validation.constraints.NotNull"));
+        assertThat(vrm.formatMessage(), is("must not be null"));
     }
 
     /**
@@ -58,8 +81,8 @@ public class ConstraintViolationConverterTest {
         List<Message> convert = sut.convert(violations);
         ValidationResultMessage vrm = (ValidationResultMessage) convert.get(0);
         assertThat(vrm.getPropertyName(), is("name"));
-        assertThat(vrm.getMessageId(), is("javax.validation.constraints.NotNull"));
-        assertThat(vrm.formatMessage(), is("may not be null"));
+        assertThat(vrm.getMessageId(), is("jakarta.validation.constraints.NotNull"));
+        assertThat(vrm.formatMessage(), is("must not be null"));
     }
 
     static class TestBean {

--- a/src/test/java/nablarch/core/validation/ee/DecimalRangeValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/DecimalRangeValidatorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.*;
 import java.math.BigDecimal;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 
 import org.hamcrest.collection.IsCollectionWithSize;
 

--- a/src/test/java/nablarch/core/validation/ee/DigitsTest.java
+++ b/src/test/java/nablarch/core/validation/ee/DigitsTest.java
@@ -7,7 +7,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 
 import org.hamcrest.collection.IsCollectionWithSize;
 

--- a/src/test/java/nablarch/core/validation/ee/DomainValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/DomainValidatorTest.java
@@ -5,9 +5,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import org.junit.Test;
 

--- a/src/test/java/nablarch/core/validation/ee/ItemNamedConstraintViolationConverterTest.java
+++ b/src/test/java/nablarch/core/validation/ee/ItemNamedConstraintViolationConverterTest.java
@@ -14,13 +14,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.ConstraintViolation;
-import javax.validation.Payload;
-import javax.validation.Valid;
-import javax.validation.Validator;
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Payload;
+import jakarta.validation.Valid;
+import jakarta.validation.Validator;
 
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Description;

--- a/src/test/java/nablarch/core/validation/ee/LengthValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/LengthValidatorTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.*;
 import java.util.Iterator;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.Test;

--- a/src/test/java/nablarch/core/validation/ee/NablarchMessageInterpolatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/NablarchMessageInterpolatorTest.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;

--- a/src/test/java/nablarch/core/validation/ee/NumberRangeValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/NumberRangeValidatorTest.java
@@ -1,7 +1,7 @@
 package nablarch.core.validation.ee;
 
 import java.util.Set;
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 
 import org.junit.Test;
 

--- a/src/test/java/nablarch/core/validation/ee/RequiredValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/RequiredValidatorTest.java
@@ -1,8 +1,8 @@
 package nablarch.core.validation.ee;
 
 import java.util.Set;
-import javax.validation.ConstraintViolation;
-import javax.validation.groups.Default;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.groups.Default;
 
 import org.junit.Test;
 

--- a/src/test/java/nablarch/core/validation/ee/SampleBean.java
+++ b/src/test/java/nablarch/core/validation/ee/SampleBean.java
@@ -30,6 +30,6 @@ public class SampleBean {
     @Domain("name")
     String domainTest;
 
-    @javax.validation.constraints.Digits(integer = 5, fraction = 2)
+    @jakarta.validation.constraints.Digits(integer = 5, fraction = 2)
     String digitsTest;
 }

--- a/src/test/java/nablarch/core/validation/ee/SizeValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/SizeValidatorTest.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolation;
 
 import org.hamcrest.collection.IsCollectionWithSize;
 

--- a/src/test/java/nablarch/core/validation/ee/SystemCharValidatorTest.java
+++ b/src/test/java/nablarch/core/validation/ee/SystemCharValidatorTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/nablarch/core/validation/ee/ValidatorUtilTest.java
+++ b/src/test/java/nablarch/core/validation/ee/ValidatorUtilTest.java
@@ -1,5 +1,6 @@
 package nablarch.core.validation.ee;
 
+import jakarta.validation.ClockProvider;
 import nablarch.core.message.ApplicationException;
 import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
@@ -8,13 +9,13 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.validation.ConstraintValidatorFactory;
-import javax.validation.MessageInterpolator;
-import javax.validation.ParameterNameProvider;
-import javax.validation.TraversableResolver;
-import javax.validation.Validator;
-import javax.validation.ValidatorContext;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintValidatorFactory;
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.ParameterNameProvider;
+import jakarta.validation.TraversableResolver;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorContext;
+import jakarta.validation.ValidatorFactory;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +46,7 @@ public class ValidatorUtilTest {
     }
 
     /**
-     * {@link ValidatorFactoryBuilder}を設定していない場合、デフォルトの{@link javax.validation.ValidatorFactory}が取得できること。
+     * {@link ValidatorFactoryBuilder}を設定していない場合、デフォルトの{@link jakarta.validation.ValidatorFactory}が取得できること。
      */
     @Test
     public void testGetDefaultValidatorFactory() {
@@ -53,7 +54,7 @@ public class ValidatorUtilTest {
     }
 
     /**
-     * {@link ValidatorFactoryBuilder}を設定した場合、カスタムの{@link javax.validation.ValidatorFactory}が取得できること。
+     * {@link ValidatorFactoryBuilder}を設定した場合、カスタムの{@link jakarta.validation.ValidatorFactory}が取得できること。
      */
     @Test
     public void testGetCustomValidatorFactory() {
@@ -227,7 +228,7 @@ public class ValidatorUtilTest {
             ValidatorUtil.validate(new SampleBean(), "test1");
         } catch (Exception e) {
             assertTrue(e instanceof IllegalArgumentException);
-            assertTrue(e.getMessage().startsWith("HV000039"));
+            assertTrue(e.getMessage().startsWith("HV000227"));
         }
     }
 
@@ -273,6 +274,8 @@ public class ValidatorUtilTest {
         public ConstraintValidatorFactory getConstraintValidatorFactory() { return null; }
         @Override
         public ParameterNameProvider getParameterNameProvider() { return null; }
+        @Override
+        public ClockProvider getClockProvider() { throw new UnsupportedOperationException(); }
         @Override
         public <T> T unwrap(Class<T> aClass) { return null; }
         @Override


### PR DESCRIPTION
`ConstraintViolationConverterTest` の修正は、リソースバンドルの言語を環境に依存しないように調整したもの。
元は英語メッセージしかなかったが、アップデートで日本語メッセージが追加されたことでメッセージが日本語で出力されるようになり、検証が通らなくなっていた。
実行環境に依存しないように英語に固定するように修正した。

`ValidatorUtilTest.java` のメッセージIDを変更しているのは、アップデートでメッセージIDが変わったことによる対応。